### PR TITLE
fix: decrease `width-request` of main window to properly support Linux mobile

### DIFF
--- a/data/io.github.zaedus.spider.desktop.in
+++ b/data/io.github.zaedus.spider.desktop.in
@@ -6,3 +6,4 @@ Terminal=false
 Type=Application
 StartupNotify=true
 Categories=Network;WebBrowser;
+X-Purism-FormFactor=Workstation;Mobile;

--- a/data/io.github.zaedus.spider.metainfo.xml.in
+++ b/data/io.github.zaedus.spider.metainfo.xml.in
@@ -19,6 +19,9 @@
     <control>keyboard</control>
     <control>touch</control>
   </supports>
+  <requires>
+    <display_length compare="ge">360</display_length>
+  </requires>
   <branding>
     <color type="primary" scheme_preference="light">#c084fc</color>
     <color type="primary" scheme_preference="dark">#6b21a8</color>

--- a/src/window.blp
+++ b/src/window.blp
@@ -4,7 +4,7 @@ using Adw 1;
 template $SpiderWindow: Adw.ApplicationWindow {
   default-width: 800;
   default-height: 600;
-  width-request: 400;
+  width-request: 360;
   height-request: 200;
 
   Adw.Breakpoint {


### PR DESCRIPTION
The app is working fairly well on Mobile Linux as is but this should improve the experience (and also include the app is the [Mobile Apps/On the go section in Flathub](https://flathub.org/apps/collection/mobile/1) + show that the app is mobile friendly in the Gnome Software Center).

From https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines#desktop-and-mobile-apps :
"Apps that support and work on mobile, tablet and desktop typically should have:
```xml
<recommends>
  <control>keyboard</control>
  <control>pointing</control>
  <control>touch</control>
</recommends>
<requires>
  <display_length compare="ge">360</display_length>
</requires>
```
"

I didn't notice any issues with this change when the width of the app is 360px