### PR TITLE
Feature/fit phone screens

### DIFF
--- a/data/io.github.zaedus.spider.metainfo.xml.in
+++ b/data/io.github.zaedus.spider.metainfo.xml.in
@@ -14,6 +14,9 @@
   <metadata_license>FSFAP</metadata_license>
   <project_license>GPL-3.0-only</project_license>
   <content_rating type="oars-1.1" />
+  <requires>
+    <display_length compare="ge">360</display_length>
+  </requires>
   <supports>
     <control>pointing</control>
     <control>keyboard</control>

--- a/src/window.blp
+++ b/src/window.blp
@@ -4,7 +4,7 @@ using Adw 1;
 template $SpiderWindow: Adw.ApplicationWindow {
   default-width: 800;
   default-height: 600;
-  width-request: 400;
+  width-request: 360;
   height-request: 200;
 
   Adw.Breakpoint {


### PR DESCRIPTION
Hi, 
thank you for creating this nice app!

This PR changes two things:
- lower minimum window width to 360 logical pixels  (360 is the magic value for [flathub](https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines/#display-size) and on [devices](https://linuxphoneapps.org/docs/resources/developer-information/#hardware-specs-to-consider) - I have tested this on mobile desktop and did not notice any side effects
- metainfo:
  - it marks it as adaptive for phones
  - this will also make the app show up in [Flathub's Mobile Collection](https://flathub.org/en/apps/collection/mobile/1).

Thank you in advance for considering this PR!

Cheers,
Peter

PS: I have also tested the app against GNOME runtime 49 - I'll happily send a PR for that, if you are interested.