### PR TITLE
Add option to hide titlebar

### DIFF
--- a/src/app_page.blp
+++ b/src/app_page.blp
@@ -93,6 +93,12 @@ template $AppPage: Adw.NavigationPage {
               subtitle: "Toggles the usage of the page's theme color in the titlebar";
               activated => $update_unsaved_details_cb() swapped;
             }
+
+            Adw.SwitchRow hide_titlebar {
+              title: "Hide Titlebar";
+              subtitle: "Hides the navigation bar when viewing the web app";
+              activated => $update_unsaved_details_cb() swapped;
+            }
           }
           Adw.PreferencesGroup {
             title: "Browser Behavior";

--- a/src/app_page.rs
+++ b/src/app_page.rs
@@ -58,6 +58,8 @@ mod imp {
         #[template_child]
         pub titlebar_color: TemplateChild<adw::SwitchRow>,
         #[template_child]
+        pub hide_titlebar: TemplateChild<adw::SwitchRow>,
+        #[template_child]
         pub user_agent_expander: TemplateChild<adw::ExpanderRow>,
         #[template_child]
         pub user_agent_entry: TemplateChild<adw::EntryRow>,
@@ -167,6 +169,7 @@ mod imp {
                 url: self.url_entry.text().to_string(),
                 title: self.title_entry.text().to_string(),
                 has_titlebar_color: self.titlebar_color.is_active(),
+                hide_titlebar: self.hide_titlebar.is_active(),
                 user_agent: self
                     .user_agent_expander
                     .enables_expansion()
@@ -222,6 +225,7 @@ mod imp {
             self.title_entry.set_text(details.title.as_str());
             self.url_entry.set_text(details.url.as_str());
             self.titlebar_color.set_active(details.has_titlebar_color);
+            self.hide_titlebar.set_active(details.hide_titlebar);
             self.user_agent_expander
                 .set_enable_expansion(details.user_agent.is_some());
             if let Some(user_agent) = &details.user_agent {
@@ -247,6 +251,13 @@ mod imp {
         }
         fn setup_signals(&self) {
             self.titlebar_color.connect_active_notify(clone!(
+                #[weak(rename_to=_self)]
+                self,
+                move |_| {
+                    _self.update_unsaved_details();
+                }
+            ));
+            self.hide_titlebar.connect_active_notify(clone!(
                 #[weak(rename_to=_self)]
                 self,
                 move |_| {

--- a/src/app_window.rs
+++ b/src/app_window.rs
@@ -100,6 +100,7 @@ mod imp {
             self.webview_container.set_child(Some(&webview));
             self.webview.replace(webview);
 
+            self.toolbar.set_reveal_top_bars(!details.hide_titlebar);
             self.load_colors(None);
         }
 

--- a/src/app_window.rs
+++ b/src/app_window.rs
@@ -395,6 +395,12 @@ impl AppWindow {
             gio::ActionEntry::builder("back")
                 .activate(move |win: &Self, _, _| win.imp().go_back())
                 .build(),
+            gio::ActionEntry::builder("toggle-titlebar")
+                .activate(move |win: &Self, _, _| {
+                    let toolbar = &win.imp().toolbar;
+                    toolbar.set_reveal_top_bars(!toolbar.reveals_top_bars());
+                })
+                .build(),
         ]);
     }
     fn setup_gestures(&self) {

--- a/src/application.rs
+++ b/src/application.rs
@@ -48,6 +48,7 @@ mod imp {
             obj.set_accels_for_action("app.quit", &["<primary>q"]);
             obj.set_accels_for_action("win.back", &["<alt>Left", "Back"]);
             obj.set_accels_for_action("win.forward", &["<alt>Right", "Forward"]);
+            obj.set_accels_for_action("win.toggle-titlebar", &["F11"]);
         }
     }
 

--- a/src/apps.rs
+++ b/src/apps.rs
@@ -32,6 +32,7 @@ pub struct AppDetails {
     pub title: String,
     pub icon: Option<Vec<u8>>,
     pub has_titlebar_color: bool,
+    pub hide_titlebar: bool,
     pub window_width: i32,
     pub window_height: i32,
     pub window_maximize: bool,
@@ -45,6 +46,7 @@ impl PartialEq for AppDetails {
             && self.title == other.title
             && self.icon == other.icon
             && self.has_titlebar_color == other.has_titlebar_color
+            && self.hide_titlebar == other.hide_titlebar
             && self.user_agent == other.user_agent
     }
 }
@@ -56,6 +58,7 @@ impl Default for AppDetails {
             url: "".into(),
             title: "".into(),
             has_titlebar_color: true,
+            hide_titlebar: false,
             icon: None,
             window_width: 400,
             window_height: 400,
@@ -81,6 +84,10 @@ impl AppDetails {
             (
                 "hastitlebarcolor".to_string(),
                 self.has_titlebar_color.to_string(),
+            ),
+            (
+                "hidetitlebar".to_string(),
+                self.hide_titlebar.to_string(),
             ),
             ("windowwidth".to_string(), self.window_width.to_string()),
             ("windowheight".to_string(), self.window_height.to_string()),
@@ -163,6 +170,9 @@ pub fn get_app_details(id: &str) -> Option<AppDetails> {
         has_titlebar_color: settings
             .get("hastitlebarcolor")
             .is_none_or(|x| x != "false"),
+        hide_titlebar: settings
+            .get("hidetitlebar")
+            .is_some_and(|x| x == "true"),
         icon: None,
         window_width: settings
             .get("windowwidth")


### PR DESCRIPTION
Useful for users of tiling window managers such as Hyprland, Niri, etc., where the native window decorations and titlebar are not needed or conflict with the DE's own management.

- Adds a "Hide Titlebar" toggle to the per-app settings page, allowing users to hide the navigation bar when viewing a web app
- The setting is persisted per app alongside existing settings
- Adds an F11 keybind to toggle the titlebar visibility at runtime without opening settings

I chose F11 to stay out of the way of ctrl / alt key combinations which might be particularly used for web-based photo-editors, etc - but you may wish to change this default

Great project, Thanks!

<img width="604" height="193" alt="screenshot-2026-04-07_19-56-35" src="https://github.com/user-attachments/assets/18599cac-1c11-45af-a4d7-a7c8fa1461a8" />

![Toggle Example](https://github.com/user-attachments/assets/db220749-9b88-496d-a82f-f5a322727338)
