### PR TITLE
feat: implement all planned features

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,21 +22,26 @@
 - [x] **Adaptive window styling**: Each app's titlebar adapts to it's [theme color](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta/name/theme-color)
 - [x] **High quality favicons**: Scrapes websites for a high quality favicon to use
 - [x] **Custom user agents**: Lets you set the app's [user agent](https://en.wikipedia.org/wiki/User_agent) if a website isn't behaving
-
-## Planned ✔️
-
-- [ ] Website permissions
-- [ ] Get website data via webview
-- [ ] Option to autostart and run apps in background
-- [ ] Domain restriction
-- [ ] More keybinds in web app
-- [ ] HTTP Proxy settings
-- [ ] Handle pop ups
+- [x] **Website permissions**: Camera, microphone, location and notification prompts are remembered per site and can be revoked anytime from the app's settings page
+- [x] **Website data via webview**: App metadata is fetched by rendering the site in a hidden webview, so JS-driven titles/icons work too
+- [x] **Autostart & background**: Apps can launch at login and keep running when their window is closed (relaunching re-presents the running window)
+- [x] **Domain restriction**: Optionally lock an app to its own domains; everything else opens in the system browser
+- [x] **More keybinds**: Reload (<Ctrl>R/F5), force reload (<Ctrl><Shift>R), stop (Esc), zoom (<Ctrl>+/-/0) and start page (<Alt>Home)
+- [x] **HTTP proxy settings**: Per-app proxy configuration
+- [x] **Pop up handling**: `window.open` pop ups open in a small window sharing the app's session
 
 > ✨ Please let me know if you'd like any more features! ✨
 
 > DO NOT BE AFRIAD TO SUBMIT BUGS!
 > I know there is lots of web functionality that you might be missing
+
+### Known limitations ⚠️
+
+- **WebRTC calls** (e.g. WhatsApp/Meet calls) need `RTCPeerConnection`, which most distros
+  compile out of WebKitGTK (`ENABLE_WEB_RTC` is an experimental feature, off by default in
+  release builds). Camera/mic *capture* works, but peer-to-peer calls will report the
+  browser as unsupported until your distribution ships WebKitGTK with
+  `-DENABLE_WEB_RTC=ON`. This is an engine limitation, not a Spider setting.
 
 ## Building 🛠️
 

--- a/src/app_page.blp
+++ b/src/app_page.blp
@@ -102,6 +102,7 @@ template $AppPage: Adw.NavigationPage {
               show-enable-switch: true;
               expanded: bind user_agent_expander.enable-expansion;
               title: "Custom User Agent";
+              subtitle: "Set the app's user agent if a website isn't behaving";
               notify => $update_unsaved_details_notify_cb() swapped;
 
               Adw.EntryRow user_agent_entry {
@@ -110,12 +111,68 @@ template $AppPage: Adw.NavigationPage {
                 apply => $update_unsaved_details_cb() swapped;
               }
             }
+
+            Adw.ExpanderRow domain_restriction_expander {
+              show-enable-switch: true;
+              expanded: bind domain_restriction_expander.enable-expansion;
+              title: "Domain Restriction";
+              subtitle: "Only let the app browse its own domains";
+              notify => $update_unsaved_details_notify_cb() swapped;
+
+              Adw.EntryRow domains_entry {
+                title: "Allowed Domains";
+                show-apply-button: true;
+                apply => $update_unsaved_details_cb() swapped;
+              }
+            }
           }
-        }
+
+          Adw.PreferencesGroup {
+            title: "Network";
+            description: "Connection settings";
+
+            Adw.ExpanderRow proxy_expander {
+              show-enable-switch: true;
+              expanded: bind proxy_expander.enable-expansion;
+              title: "HTTP Proxy";
+              notify => $update_unsaved_details_notify_cb() swapped;
+
+              Adw.EntryRow proxy_entry {
+                title: "Proxy URL";
+                show-apply-button: true;
+                apply => $update_unsaved_details_cb() swapped;
+              }
+            }
+          }
+
+          Adw.PreferencesGroup {
+            title: "System Integration";
+            description: "How the app integrates with the system";
+
+            Adw.SwitchRow autostart_row {
+              title: "Start Automatically";
+              subtitle: "Launch this app when you log in";
+              activated => $update_unsaved_details_cb() swapped;
+            }
+
+            Adw.SwitchRow background_row {
+              title: "Run in Background";
+              subtitle: "Closing the window keeps the app running";
+              activated => $update_unsaved_details_cb() swapped;
+            }
+          }
+
+          Adw.PreferencesGroup {
+            title: "Website Permissions";
+            description: "Revoke access that was granted to websites";
+
+            Adw.ExpanderRow permissions_expander {}
+          }
+            }
+          }
       }
     }
   }
-}
 
 // This is a template child that gets populated when the page is built
 // Until there is a good way of accessing the menu's items (so that I can set the action target),

--- a/src/app_page.rs
+++ b/src/app_page.rs
@@ -8,6 +8,7 @@ use std::cell::RefCell;
 use ashpd::WindowIdentifier;
 
 use crate::apps::{self, AppDetails};
+use crate::application;
 use crate::util;
 
 fn menu_item_and_target(label: &str, action_name: &str, action_target: &str) -> gio::MenuItem {
@@ -63,6 +64,26 @@ mod imp {
         pub user_agent_expander: TemplateChild<adw::ExpanderRow>,
         #[template_child]
         pub user_agent_entry: TemplateChild<adw::EntryRow>,
+        #[template_child]
+        pub domain_restriction_expander: TemplateChild<adw::ExpanderRow>,
+        #[template_child]
+        pub domains_entry: TemplateChild<adw::EntryRow>,
+        #[template_child]
+        pub proxy_expander: TemplateChild<adw::ExpanderRow>,
+        #[template_child]
+        pub proxy_entry: TemplateChild<adw::EntryRow>,
+        #[template_child]
+        pub autostart_row: TemplateChild<adw::SwitchRow>,
+        #[template_child]
+        pub background_row: TemplateChild<adw::SwitchRow>,
+        #[template_child]
+        pub permissions_expander: TemplateChild<adw::ExpanderRow>,
+
+        // Dynamically built permission summary rows
+        permission_rows: RefCell<Vec<gtk::Widget>>,
+
+        // gsettings "apps-settings" change handler, disconnected on dispose
+        settings_handler: RefCell<Option<glib::SignalHandlerId>>,
     }
 
     #[glib::object_subclass]
@@ -85,6 +106,12 @@ mod imp {
             self.parent_constructed();
 
             self.setup_signals();
+        }
+
+        fn dispose(&self) {
+            if let Some(handler) = self.settings_handler.borrow_mut().take() {
+                application::settings().disconnect(handler);
+            }
         }
     }
     impl WidgetImpl for AppPage {}
@@ -173,6 +200,24 @@ mod imp {
                     .user_agent_expander
                     .enables_expansion()
                     .then(|| self.user_agent_entry.text().to_string()),
+                allowed_domains: self
+                    .domain_restriction_expander
+                    .enables_expansion()
+                    .then(|| {
+                        self.domains_entry
+                            .text()
+                            .split(',')
+                            .map(|d| d.trim().to_lowercase())
+                            .filter(|d| !d.is_empty())
+                            .collect::<Vec<String>>()
+                    }),
+                proxy_url: self
+                    .proxy_expander
+                    .enables_expansion()
+                    .then(|| self.proxy_entry.text().to_string())
+                    .filter(|x| !x.is_empty()),
+                autostart: self.autostart_row.is_active(),
+                run_in_background: self.background_row.is_active(),
                 icon,
                 ..details
             };
@@ -207,6 +252,9 @@ mod imp {
                     }
                     _ => (),
                 }
+                // Keep the XDG autostart entry in sync with the saved
+                // setting (creating/removing it is idempotent)
+                apps::set_app_autostart(&unsaved_details, unsaved_details.autostart)?;
                 self.set_details(&unsaved_details);
             }
             self.update_unsaved_details();
@@ -240,8 +288,38 @@ mod imp {
             if let Some(user_agent) = &details.user_agent {
                 self.user_agent_entry.set_text(user_agent.as_str());
             }
+            self.domain_restriction_expander
+                .set_enable_expansion(details.allowed_domains.is_some());
+            if let Some(domains) = &details.allowed_domains {
+                self.domains_entry.set_text(domains.join(", ").as_str());
+            }
+            self.proxy_expander
+                .set_enable_expansion(details.proxy_url.is_some());
+            if let Some(proxy_url) = &details.proxy_url {
+                self.proxy_entry.set_text(proxy_url.as_str());
+            }
+            self.autostart_row.set_active(details.autostart);
+            self.background_row.set_active(details.run_in_background);
 
             self.setup_menu();
+            self.setup_permissions();
+
+            // Keep the permissions list live: decisions are saved by the
+            // app's own window process, so rebuild whenever the underlying
+            // settings change.
+            if self.settings_handler.borrow().is_none() {
+                let handler = application::settings().connect_changed(
+                    Some("apps-settings"),
+                    clone!(
+                        #[weak(rename_to=_self)]
+                        self,
+                        move |_, _| {
+                            _self.setup_permissions();
+                        }
+                    ),
+                );
+                *self.settings_handler.borrow_mut() = Some(handler);
+            }
         }
         async fn set_unsaved_icon(&self, file: &gio::File) -> anyhow::Result<()> {
             let (buffer, _etag) = file.load_contents_future().await?;
@@ -267,6 +345,107 @@ mod imp {
                     _self.update_unsaved_details();
                 }
             ));
+            // Toggling a switch doesn't emit "activated", so listen for
+            // the active property instead
+            self.autostart_row.connect_active_notify(clone!(
+                #[weak(rename_to=_self)]
+                self,
+                move |_| {
+                    _self.update_unsaved_details();
+                }
+            ));
+            self.background_row.connect_active_notify(clone!(
+                #[weak(rename_to=_self)]
+                self,
+                move |_| {
+                    _self.update_unsaved_details();
+                }
+            ));
+            // The enable-switch of the expanders likewise needs
+            // notify::enable-expansion to mark unsaved changes
+            self.user_agent_expander
+                .connect_enable_expansion_notify(clone!(
+                    #[weak(rename_to=_self)]
+                    self,
+                    move |_| {
+                        _self.update_unsaved_details();
+                    }
+                ));
+            self.domain_restriction_expander
+                .connect_enable_expansion_notify(clone!(
+                    #[weak(rename_to=_self)]
+                    self,
+                    move |_| {
+                        _self.update_unsaved_details();
+                    }
+                ));
+            self.proxy_expander.connect_enable_expansion_notify(clone!(
+                #[weak(rename_to=_self)]
+                self,
+                move |_| {
+                    _self.update_unsaved_details();
+                }
+            ));
+        }
+        /// Rebuilds the "Website Permissions" list: one row per origin
+        /// that has saved decisions, each with a button to revoke them.
+        fn setup_permissions(&self) {
+            // Clear previous rows
+            for row in self.permission_rows.borrow_mut().drain(..) {
+                self.permissions_expander.remove(&row);
+            }
+
+            let id = self.details.borrow().id.clone();
+            let summaries = apps::get_permission_summaries(&id);
+
+            let mut rows = self.permission_rows.borrow_mut();
+            if summaries.is_empty() {
+                let row = adw::ActionRow::new();
+                row.set_title("No permissions requested");
+                row.set_sensitive(false);
+                self.permissions_expander.add_row(&row);
+                rows.push(row.upcast());
+                return;
+            }
+
+            for (origin, kinds) in summaries {
+                let row = adw::ActionRow::new();
+                row.set_title(origin.as_str());
+                row.set_subtitle(
+                    &kinds
+                        .iter()
+                        .map(|kind| apps::permission_label(kind))
+                        .collect::<Vec<_>>()
+                        .join(", "),
+                );
+
+                let revoke_button = gtk::Button::builder()
+                    .icon_name("user-trash-symbolic")
+                    .tooltip_text("Revoke all access")
+                    .valign(gtk::Align::Center)
+                    .css_classes(["flat", "destructive-action"])
+                    .build();
+                revoke_button.connect_clicked(clone!(
+                    #[weak(rename_to=_self)]
+                    self,
+                    #[weak]
+                    row,
+                    move |_| {
+                        let id = _self.details.borrow().id.clone();
+                        let origin = row.title().to_string();
+                        if let Err(err) = apps::clear_origin_permissions(&id, &origin) {
+                            _self.toast(err.to_string());
+                            return;
+                        }
+                        _self.toast(format!("Revoked access for {origin}"));
+                        _self.setup_permissions();
+                    }
+                ));
+
+                row.add_suffix(&revoke_button);
+                self.permissions_expander.add_row(&row);
+                rows.push(row.upcast());
+            }
         }
     }
 }

--- a/src/app_window.rs
+++ b/src/app_window.rs
@@ -2,11 +2,18 @@ use adw::prelude::*;
 use adw::subclass::prelude::*;
 use glib::clone;
 use gtk::{gdk, gio, glib};
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
+use std::rc::Rc;
+use url::Url;
 use webkit::prelude::*;
-use webkit::{HardwareAccelerationPolicy, PolicyDecisionType, WebContext, WebView};
+use webkit::{
+    HardwareAccelerationPolicy, LoadEvent, NetworkProxyMode, NetworkProxySettings,
+    PolicyDecisionType, WebContext, WebView,
+};
 
-use crate::apps::{get_app_details, AppDetails};
+use crate::apps::{
+    self, get_app_details, get_app_permission, permission_label, set_app_permission, AppDetails,
+};
 
 fn format_css(id: &str, bg: &str, fg: &str) -> String {
     format!(
@@ -20,6 +27,81 @@ fn format_css(id: &str, bg: &str, fg: &str) -> String {
 // Source: https://www.w3.org/WAI/GL/wiki/Relative_luminance
 fn luminence(rgba: gdk::RGBA) -> f32 {
     0.2126 * rgba.red() + 0.7152 * rgba.green() + 0.0722 * rgba.blue()
+}
+
+/// Checks whether navigating to `uri` is allowed by the app's domain
+/// restriction. Subdomains of an allowed domain are allowed too. URIs
+/// without a host (about:, blob:, data:, ...) are always allowed since
+/// web apps commonly rely on them internally.
+fn uri_allowed(allowed_domains: &Option<Vec<String>>, uri: &str) -> bool {
+    let Some(allowed) = allowed_domains else {
+        return true;
+    };
+    let Ok(url) = Url::parse(uri) else {
+        return false;
+    };
+    match url.host_str() {
+        None => true,
+        Some(host) => {
+            let host = host.to_lowercase();
+            allowed
+                .iter()
+                .any(|domain| host == *domain || host.ends_with(&format!(".{domain}")))
+        }
+    }
+}
+
+/// The scheme://host[:port] origin of a URI, used as the storage key for
+/// website permissions.
+fn page_origin(uri: Option<&str>) -> Option<String> {
+    let url = Url::parse(uri?).ok()?;
+    let host = url.host_str()?;
+    Some(match url.port() {
+        Some(port) => format!("{}://{host}:{port}", url.scheme()),
+        None => format!("{}://{host}", url.scheme()),
+    })
+}
+
+/// Maps WebKit's permission API names (from PermissionStateQuery) onto our
+/// stored kinds.
+fn normalize_permission_name(name: Option<&str>) -> Option<&'static str> {
+    let name = name?;
+    if name.contains("audio") {
+        Some("microphone")
+    } else if name.contains("video") {
+        Some("camera")
+    } else {
+        apps::PERMISSION_LABELS
+            .iter()
+            .find(|(kind, _)| *kind == name)
+            .map(|(kind, _)| *kind)
+    }
+}
+
+/// Which stored permission kinds a WebKit permission request maps to.
+/// Multiple kinds are returned when e.g. camera AND microphone are both
+/// requested; all of them share one prompt/decision.
+fn permission_kinds(request: &webkit::PermissionRequest) -> Vec<&'static str> {
+    if let Ok(media) = request
+        .clone()
+        .upcast::<glib::Object>()
+        .downcast::<webkit::UserMediaPermissionRequest>()
+    {
+        let mut kinds = Vec::new();
+        if media.is_for_audio_device() {
+            kinds.push("microphone");
+        }
+        if media.is_for_video_device() {
+            kinds.push("camera");
+        }
+        return kinds;
+    }
+    let type_name = request.type_().name();
+    match type_name {
+        "WebKitNotificationPermissionRequest" => vec!["notifications"],
+        "WebKitGeolocationPermissionRequest" => vec!["geolocation"],
+        _ => Vec::new(),
+    }
 }
 
 mod imp {
@@ -76,6 +158,14 @@ mod imp {
                 details.window_height = size.1;
                 details.window_maximize = self.obj().is_maximized();
                 details.save().unwrap(); // App is closing, shouldn't fail really ever
+            }
+
+            // "Run in background": hide the window instead of closing so
+            // the app keeps running (reopening it from the launcher
+            // presents this same instance again)
+            if self.details.borrow().run_in_background {
+                self.obj().set_visible(false);
+                return glib::Propagation::Stop;
             }
             glib::Propagation::Proceed
         }
@@ -155,7 +245,9 @@ mod imp {
             let mut settings = webkit::Settings::builder()
                 .enable_webgl(true)
                 .enable_webrtc(true)
-                .enable_webaudio(true)
+                // Required for getUserMedia + RTCPeerConnection; sites like
+                // WhatsApp Web report "calling not supported" without it
+                .enable_media_stream(true)
                 .enable_media(true)
                 .enable_mediasource(true)
                 .enable_encrypted_media(true)
@@ -176,6 +268,12 @@ mod imp {
                 .cache_directory(app_cache_dir.to_str().unwrap())
                 .data_directory(app_data_dir.join("data").to_str().unwrap())
                 .build();
+
+            // Apply custom HTTP proxy if one is configured
+            if let Some(proxy_url) = &details.proxy_url {
+                let proxy_settings = NetworkProxySettings::new(Some(proxy_url.as_str()), &[]);
+                network_session.set_proxy_settings(NetworkProxyMode::Custom, Some(&proxy_settings));
+            }
 
             network_session.connect_download_started(|_, dl| {
                 dl.connect_decide_destination(move |dl, dest| {
@@ -255,48 +353,68 @@ mod imp {
                 .web_context(&web_context)
                 .build();
 
-            webview.connect_decide_policy(|webview, decision, decision_type| {
-                if decision_type == PolicyDecisionType::NewWindowAction {
-                    if let Some(action) = decision
-                        .clone()
-                        .downcast::<webkit::NavigationPolicyDecision>()
-                        .ok()
-                        .and_then(|x| x.navigation_action())
-                    {
-                        if let Some(uri) = action.request().and_then(|a| a.uri()) {
-                            open::that_detached(uri).unwrap();
+            // Set to true once the start page finished loading; the very
+            // first navigation is always allowed even under domain
+            // restriction
+            let initial_load_done = std::rc::Rc::new(Cell::new(false));
 
-                            decision.ignore();
-                            return false;
-                        }
+            {
+                let initial_load_done = initial_load_done.clone();
+                webview.connect_load_changed(move |_, event| {
+                    if event == LoadEvent::Finished {
+                        initial_load_done.set(true);
                     }
-                }
-                if decision_type == PolicyDecisionType::Response {
-                    if let Some(headers) = decision
-                        .clone()
-                        .downcast::<webkit::ResponsePolicyDecision>()
-                        .ok()
-                        .and_then(|x| x.response())
-                        .and_then(|x| x.http_headers())
-                    {
-                        if headers
-                            .one("Content-Type")
-                            .and_then(|x| {
-                                if webview.can_show_mime_type(x.as_str()) {
-                                    Some(())
-                                } else {
-                                    None
-                                }
-                            })
-                            .is_none()
-                        {
-                            decision.download();
-                            return true;
-                        }
-                    }
-                }
-                true
-            });
+                });
+            }
+
+
+            {
+                let allowed_domains = details.allowed_domains.clone();
+                let initial_load_done = initial_load_done.clone();
+                webview.connect_decide_policy(move |webview, decision, decision_type| -> bool {
+                    decide_policy(
+                        &allowed_domains,
+                        &initial_load_done,
+                        webview,
+                        decision,
+                        decision_type,
+                    )
+                });
+            }
+
+            // Script-initiated pop ups (window.open). Links that trigger a
+            // NewWindowAction policy are opened externally in
+            // decide_policy instead.
+            {
+                let allowed_domains = details.allowed_domains.clone();
+                let parent = self.obj().downgrade();
+                webview.connect_create(move |_, navigation_action| -> Option<gtk::Widget> {
+                    create_popup(
+                        &allowed_domains,
+                        &parent,
+                        &network_session,
+                        &web_context,
+                        &settings,
+                        navigation_action,
+                    )
+                });
+            }
+
+            // Website permissions: apply previously saved decisions
+            // without prompting, and ask the user otherwise. Decisions are
+            // stored per app + origin so they can be revoked later from
+            // the app's settings page.
+            {
+                let id = details.id.clone();
+                let parent = self.obj().downgrade();
+                let id_state = id.clone();
+                webview.connect_query_permission_state(move |webview, query| -> bool {
+                    query_permission_state(&id_state, webview, query)
+                });
+                webview.connect_permission_request(move |webview, request| -> bool {
+                    permission_request(&id, &parent, webview, request)
+                });
+            }
 
             webview.connect_estimated_load_progress_notify(clone!(
                 #[weak(rename_to=_self)]
@@ -392,7 +510,48 @@ impl AppWindow {
             gio::ActionEntry::builder("back")
                 .activate(move |win: &Self, _, _| win.imp().go_back())
                 .build(),
+            gio::ActionEntry::builder("reload")
+                .activate(move |win: &Self, _, _| {
+                    win.imp().webview.borrow().reload();
+                })
+                .build(),
+            gio::ActionEntry::builder("reload-bypass-cache")
+                .activate(move |win: &Self, _, _| {
+                    win.imp().webview.borrow().reload_bypass_cache();
+                })
+                .build(),
+            gio::ActionEntry::builder("stop")
+                .activate(move |win: &Self, _, _| {
+                    win.imp().webview.borrow().stop_loading();
+                })
+                .build(),
+            gio::ActionEntry::builder("go-home")
+                .activate(move |win: &Self, _, _| {
+                    let imp = win.imp();
+                    let url = imp.details.borrow().url.clone();
+                    imp.webview.borrow().load_uri(url.as_str());
+                })
+                .build(),
+            gio::ActionEntry::builder("zoom-in")
+                .activate(move |win: &Self, _, _| win.zoom(1.2))
+                .build(),
+            gio::ActionEntry::builder("zoom-out")
+                .activate(move |win: &Self, _, _| win.zoom(1.0 / 1.2))
+                .build(),
+            gio::ActionEntry::builder("zoom-reset")
+                .activate(move |win: &Self, _, _| {
+                    win.imp().webview.borrow().set_zoom_level(1.0);
+                })
+                .build(),
         ]);
+    }
+    fn zoom(&self, factor: f64) {
+        let webview = self.imp().webview.borrow();
+        // WebKit's zoom level is relative to a default of 1.0
+        const MIN_ZOOM: f64 = 0.25;
+        const MAX_ZOOM: f64 = 5.0;
+        let new_zoom = (webview.zoom_level() * factor).clamp(MIN_ZOOM, MAX_ZOOM);
+        webview.set_zoom_level(new_zoom);
     }
     fn setup_gestures(&self) {
         let gesture = gtk::GestureClick::new();
@@ -427,4 +586,216 @@ impl AppWindow {
             self.maximize();
         }
     }
+}
+
+fn decide_policy(
+    allowed_domains: &Option<Vec<String>>,
+    initial_load_done: &Rc<Cell<bool>>,
+    webview: &WebView,
+    decision: &webkit::PolicyDecision,
+    decision_type: PolicyDecisionType,
+) -> bool {
+    match decision_type {
+        PolicyDecisionType::NewWindowAction => {
+            // Open anything targeting a new window in the system browser
+            // instead
+            if let Some(uri) = navigation_action_uri(decision) {
+                let _ = open::that_detached(uri);
+                decision.ignore();
+                return false;
+            }
+        }
+        PolicyDecisionType::NavigationAction => {
+            // Domain restriction: keep the app inside its own domains,
+            // everything else is handed to the system browser. The very
+            // first navigation (the app's start page) is always allowed.
+            if initial_load_done.get() {
+                if let Some(uri) = navigation_action_uri(decision) {
+                    if !uri_allowed(allowed_domains, &uri) {
+                        let _ = open::that_detached(uri);
+                        decision.ignore();
+                        return false;
+                    }
+                }
+            }
+        }
+        PolicyDecisionType::Response => {
+            if let Some(headers) = decision
+                .clone()
+                .downcast::<webkit::ResponsePolicyDecision>()
+                .ok()
+                .and_then(|x| x.response())
+                .and_then(|x| x.http_headers())
+            {
+                if headers
+                    .one("Content-Type")
+                    .and_then(|x| {
+                        if webview.can_show_mime_type(x.as_str()) {
+                            Some(())
+                        } else {
+                            None
+                        }
+                    })
+                    .is_none()
+                {
+                    decision.download();
+                    return true;
+                }
+            }
+        }
+        _ => (),
+    }
+    true
+}
+
+/// The target URI of a navigation policy decision, if any.
+fn navigation_action_uri(decision: &webkit::PolicyDecision) -> Option<String> {
+    decision
+        .clone()
+        .downcast::<webkit::NavigationPolicyDecision>()
+        .ok()
+        .and_then(|x| x.navigation_action())
+        .and_then(|x| x.request())
+        .and_then(|x| x.uri())
+        .map(|x| x.to_string())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn create_popup(
+    allowed_domains: &Option<Vec<String>>,
+    parent: &glib::WeakRef<AppWindow>,
+    network_session: &webkit::NetworkSession,
+    web_context: &WebContext,
+    settings: &webkit::Settings,
+    navigation_action: &webkit::NavigationAction,
+) -> Option<gtk::Widget> {
+    let uri = navigation_action.request().and_then(|r| r.uri())?;
+    if !uri_allowed(allowed_domains, &uri) {
+        // Restricted app trying to pop up an outside page: hand it to the
+        // system browser and suppress the pop up here
+        let _ = open::that_detached(uri);
+        return None;
+    }
+
+    let parent = parent.upgrade()?;
+
+    // A fresh content manager per pop up; the shared context, session and
+    // settings keep logins etc. working inside it
+    let popup_webview = WebView::builder()
+        .network_session(network_session)
+        .settings(settings)
+        .web_context(web_context)
+        .user_content_manager(&webkit::UserContentManager::new())
+        .build();
+
+    let application = parent.application()?;
+    let window = adw::ApplicationWindow::new(&application);
+    window.set_default_size(640, 480);
+    window.set_title(Some("Pop Up"));
+    window.set_transient_for(Some(&parent));
+
+    let headerbar = adw::HeaderBar::new();
+    let toolbar = adw::ToolbarView::new();
+    toolbar.add_top_bar(&headerbar);
+    toolbar.set_content(Some(&popup_webview));
+    window.set_content(Some(&toolbar));
+
+    // Follow the pop up's document title
+    popup_webview.connect_title_notify(clone!(
+        #[weak]
+        window,
+        move |webview| {
+            let title = webview.title().unwrap_or_else(|| "Pop Up".into());
+            window.set_title(Some(title.as_str()));
+        }
+    ));
+
+    window.present();
+
+    // WebKit loads the requested URI into the returned view itself
+    Some(popup_webview.upcast())
+}
+
+/// Applies a saved permission decision without prompting.
+fn query_permission_state(
+    id: &str,
+    webview: &WebView,
+    query: &webkit::PermissionStateQuery,
+) -> bool {
+    let Some(kind) = normalize_permission_name(query.name().as_deref()) else {
+        return false;
+    };
+    let Some(origin) = page_origin(webview.uri().as_deref()) else {
+        return false;
+    };
+    match get_app_permission(id, &origin, kind) {
+        Some(true) => query.finish(webkit::PermissionState::Granted),
+        Some(false) => query.finish(webkit::PermissionState::Denied),
+        None => return false,
+    }
+    true
+}
+
+/// Prompts for a website permission request and remembers the answer so it
+/// can later be revoked from the app's settings page.
+fn permission_request(
+    id: &str,
+    parent: &glib::WeakRef<AppWindow>,
+    webview: &WebView,
+    request: &webkit::PermissionRequest,
+) -> bool {
+    let kinds = permission_kinds(request);
+    if kinds.is_empty() {
+        // Unknown permission type; fall back to WebKit's default behavior
+        return false;
+    }
+    let Some(origin) = page_origin(webview.uri().as_deref()) else {
+        request.deny();
+        return true;
+    };
+
+    // Already decided?
+    let decisions: Vec<Option<bool>> = kinds
+        .iter()
+        .map(|kind| get_app_permission(id, &origin, kind))
+        .collect();
+    if decisions.iter().all(|d| d.is_some()) {
+        let allow = decisions.into_iter().flatten().all(|v| v);
+        if allow {
+            request.allow();
+        } else {
+            request.deny();
+        }
+        return true;
+    }
+
+    let title = get_app_details(id).map(|d| d.title).unwrap_or_default();
+    let kind_label = kinds
+        .iter()
+        .map(|kind| permission_label(kind))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let dialog = adw::AlertDialog::new(
+        Some(format!("Allow {title} to use {kind_label}?").as_str()),
+        Some(origin.as_str()),
+    );
+    dialog.add_responses(&[("deny", "Deny"), ("allow", "Allow")]);
+    dialog.set_response_appearance("deny", adw::ResponseAppearance::Destructive);
+    dialog.set_default_response(Some("allow"));
+    dialog.present(parent.upgrade().as_ref());
+
+    let request = request.clone();
+    let id = id.to_string();
+    dialog.connect_response(None, move |_, response| {
+        let allow = response == "allow";
+        for kind in &kinds {
+            let _ = set_app_permission(&id, &origin, kind, allow);
+        }
+        if allow {
+            request.allow();
+        } else {
+            request.deny();
+        }
+    });
+    true
 }

--- a/src/application.rs
+++ b/src/application.rs
@@ -48,6 +48,14 @@ mod imp {
             obj.set_accels_for_action("app.quit", &["<primary>q"]);
             obj.set_accels_for_action("win.back", &["<alt>Left", "Back"]);
             obj.set_accels_for_action("win.forward", &["<alt>Right", "Forward"]);
+            // Web app keybinds
+            obj.set_accels_for_action("win.reload", &["<primary>r", "F5"]);
+            obj.set_accels_for_action("win.reload-bypass-cache", &["<primary><shift>r"]);
+            obj.set_accels_for_action("win.stop", &["Escape"]);
+            obj.set_accels_for_action("win.zoom-in", &["<primary>plus", "<primary>equal"]);
+            obj.set_accels_for_action("win.zoom-out", &["<primary>minus"]);
+            obj.set_accels_for_action("win.zoom-reset", &["<primary>0"]);
+            obj.set_accels_for_action("win.go-home", &["<alt>Home"]);
         }
     }
 
@@ -74,17 +82,35 @@ mod imp {
                 return glib::ExitCode::SUCCESS;
             }
 
-            // Get or create window to present
+            // Get or create window to present. Since every app id is its
+            // own single instance, launching an app that's already running
+            // (possibly hidden in the background) re-presents its window.
             let window: gtk::Window = if let Some(id) = command_line.arguments().get(1) {
                 match get_app_details(&id.to_string_lossy())
                     .ok_or(anyhow!("No app with id {:?}", id))
                 {
-                    Ok(details) => AppWindow::new(&self.obj().clone(), &details).upcast(),
+                    Ok(details) => {
+                        let existing = application
+                            .windows()
+                            .into_iter()
+                            .find_map(|win| win.downcast::<AppWindow>().ok())
+                            .filter(|win| win.id() == details.id);
+                        match existing {
+                            Some(win) => win.upcast(),
+                            None => AppWindow::new(&self.obj().clone(), &details).upcast(),
+                        }
+                    }
                     Err(err) => {
                         eprintln!("Error: {err}");
                         return glib::ExitCode::FAILURE;
                     }
                 }
+            } else if let Some(win) = application
+                .windows()
+                .into_iter()
+                .find_map(|win| win.downcast::<SpiderWindow>().ok())
+            {
+                win.upcast()
             } else {
                 SpiderWindow::new(&*application).upcast()
             };

--- a/src/apps.rs
+++ b/src/apps.rs
@@ -36,6 +36,12 @@ pub struct AppDetails {
     pub window_height: i32,
     pub window_maximize: bool,
     pub user_agent: Option<String>,
+    /// When set, navigation inside the app is restricted to these domains
+    /// (subdomains included). `None` means unrestricted.
+    pub allowed_domains: Option<Vec<String>>,
+    pub proxy_url: Option<String>,
+    pub autostart: bool,
+    pub run_in_background: bool,
 }
 
 impl PartialEq for AppDetails {
@@ -46,6 +52,10 @@ impl PartialEq for AppDetails {
             && self.icon == other.icon
             && self.has_titlebar_color == other.has_titlebar_color
             && self.user_agent == other.user_agent
+            && self.allowed_domains == other.allowed_domains
+            && self.proxy_url == other.proxy_url
+            && self.autostart == other.autostart
+            && self.run_in_background == other.run_in_background
     }
 }
 
@@ -61,6 +71,10 @@ impl Default for AppDetails {
             window_height: 400,
             window_maximize: false,
             user_agent: None,
+            allowed_domains: None,
+            proxy_url: None,
+            autostart: false,
+            run_in_background: false,
         }
     }
 }
@@ -75,7 +89,7 @@ impl AppDetails {
         }
     }
     pub fn to_hashmap(&self) -> HashMap<String, String> {
-        let mut kv_pairs = vec![
+        let kv_pairs = vec![
             ("url".to_string(), self.url.clone()),
             ("title".to_string(), self.title.clone()),
             (
@@ -88,10 +102,26 @@ impl AppDetails {
                 "windowmaximize".to_string(),
                 self.window_maximize.to_string(),
             ),
+            // Optional fields are always stored (empty string = unset) so
+            // they can be cleared again; saves merge over previous entries
+            (
+                "useragent".to_string(),
+                self.user_agent.clone().unwrap_or_default(),
+            ),
+            (
+                "domains".to_string(),
+                self.allowed_domains
+                    .as_ref()
+                    .map(|d| d.join(","))
+                    .unwrap_or_default(),
+            ),
+            (
+                "proxyurl".to_string(),
+                self.proxy_url.clone().unwrap_or_default(),
+            ),
+            ("autostart".to_string(), self.autostart.to_string()),
+            ("background".to_string(), self.run_in_background.to_string()),
         ];
-        if let Some(user_agent) = &self.user_agent {
-            kv_pairs.push(("useragent".to_string(), user_agent.clone()));
-        }
 
         kv_pairs.into_iter().collect()
     }
@@ -112,7 +142,16 @@ impl AppDetails {
         }
 
         let mut apps_settings = settings.get::<AppsSettings>("apps-settings");
-        apps_settings.insert(self.id.clone(), self.to_hashmap());
+        // Merge into any existing entry so data managed elsewhere
+        // (e.g. website permissions) survives saves made from stale
+        // copies of the details
+        let mut kv_pairs = self.to_hashmap();
+        if let Some(existing) = apps_settings.get(&self.id) {
+            for (key, value) in existing {
+                kv_pairs.entry(key.clone()).or_insert_with(|| value.clone());
+            }
+        }
+        apps_settings.insert(self.id.clone(), kv_pairs);
 
         settings.set("app-ids", apps)?;
         settings.set("apps-settings", apps_settings)?;
@@ -140,6 +179,147 @@ pub fn delete_app_details(id: &str) -> anyhow::Result<()> {
     settings.set("app-ids", apps)?;
     settings.set("apps-settings", apps_settings)?;
 
+    Ok(())
+}
+
+/// Mutates the stored settings map for a single app in place.
+fn mutate_app_settings(
+    id: &str,
+    f: impl FnOnce(&mut HashMap<String, String>),
+) -> anyhow::Result<()> {
+    let settings = settings();
+    let mut apps_settings = settings.get::<AppsSettings>("apps-settings");
+    let Some(entry) = apps_settings.get_mut(id) else {
+        anyhow::bail!("No app with id {id}");
+    };
+    f(entry);
+    settings.set("apps-settings", apps_settings)?;
+    Ok(())
+}
+
+/// Prefix used for all website permission entries inside an app's
+/// settings map. Keys look like `perm:<origin>:<kind>` and values are
+/// `"allow"` or `"deny"`.
+pub const PERMISSION_PREFIX: &str = "perm:";
+
+pub const PERMISSION_LABELS: &[(&str, &str)] = &[
+    ("camera", "Camera"),
+    ("microphone", "Microphone"),
+    ("geolocation", "Location"),
+    ("notifications", "Notifications"),
+];
+
+pub fn permission_label(kind: &str) -> String {
+    PERMISSION_LABELS
+        .iter()
+        .find(|(k, _)| *k == kind)
+        .map(|(_, label)| label.to_string())
+        .unwrap_or_else(|| kind.to_string())
+}
+
+/// Saves the user's decision for `origin` + permission `kind`.
+/// `allow == false` stores an explicit denial (so we won't ask again).
+pub fn set_app_permission(id: &str, origin: &str, kind: &str, allow: bool) -> anyhow::Result<()> {
+    mutate_app_settings(id, |entry| {
+        entry.insert(
+            format!("{PERMISSION_PREFIX}{origin}:{kind}"),
+            if allow { "allow" } else { "deny" }.to_string(),
+        );
+    })
+}
+
+/// The saved decision for `origin` + permission `kind`, if any.
+pub fn get_app_permission(id: &str, origin: &str, kind: &str) -> Option<bool> {
+    let apps_settings = settings().get::<AppsSettings>("apps-settings");
+    apps_settings
+        .get(id)?
+        .get(format!("{PERMISSION_PREFIX}{origin}:{kind}").as_str())
+        .map(|value| value == "allow")
+}
+
+/// Removes every stored decision for `origin`, revoking all of its grants.
+pub fn clear_origin_permissions(id: &str, origin: &str) -> anyhow::Result<()> {
+    mutate_app_settings(id, |entry| {
+        let prefix = format!("{PERMISSION_PREFIX}{origin}:");
+        entry.retain(|key, _| !key.starts_with(&prefix));
+    })
+}
+
+/// Returns `(origin, granted kinds)` pairs for every origin that has at
+/// least one saved decision, sorted by origin.
+pub fn get_permission_summaries(id: &str) -> Vec<(String, Vec<String>)> {
+    let mut summaries: HashMap<String, Vec<String>> = HashMap::new();
+    if let Some(entry) = settings().get::<AppsSettings>("apps-settings").get(id) {
+        for (key, value) in entry {
+            let Some(rest) = key.strip_prefix(PERMISSION_PREFIX) else {
+                continue;
+            };
+            // Origins contain colons (https://host:port), kinds don't, so
+            // split from the right
+            let Some((origin, kind)) = rest.rsplit_once(':') else {
+                continue;
+            };
+            if value != "deny" {
+                summaries
+                    .entry(origin.to_string())
+                    .or_default()
+                    .push(kind.to_string());
+            }
+        }
+    }
+    let mut summaries: Vec<(String, Vec<String>)> = summaries.into_iter().collect();
+    summaries.sort_by(|a, b| a.0.cmp(&b.0));
+    for (_, kinds) in &mut summaries {
+        kinds.sort();
+    }
+    summaries
+}
+
+fn autostart_desktop_path(id: &str) -> PathBuf {
+    glib::user_config_dir()
+        .join("autostart")
+        .join(id_to_desktop(id))
+}
+
+/// Creates or removes an XDG autostart entry for the app.
+///
+/// The generated desktop file reuses the `Icon=` line from the launcher's
+/// own desktop file when it can be found so the autostart entry shows the
+/// same icon as the installed app.
+pub fn set_app_autostart(details: &AppDetails, enabled: bool) -> anyhow::Result<()> {
+    let path = autostart_desktop_path(&details.id);
+    if !enabled {
+        if path.exists() {
+            std::fs::remove_file(path)?;
+        }
+        return Ok(());
+    }
+
+    // Inherit the icon from the installed launcher if possible
+    let icon_line = [glib::user_data_dir()]
+        .into_iter()
+        .chain(glib::system_data_dirs())
+        .map(|dir| dir.join("applications").join(id_to_desktop(&details.id)))
+        .find_map(|desktop_path| {
+            std::fs::read_to_string(desktop_path)
+                .ok()
+                .and_then(|content| {
+                    content.lines().find_map(|line| {
+                        line.strip_prefix("Icon=")
+                            .map(|icon| format!("Icon={}", icon.trim()))
+                    })
+                })
+        });
+
+    let content = format!(
+        "[Desktop Entry]\nType=Application\nName={}\nExec=env spider {}\nTerminal=false\nX-GNOME-Autostart-enabled=true\n{}\n",
+        details.title,
+        details.id,
+        icon_line.unwrap_or_else(|| format!("Icon={}", config::APP_ID)),
+    );
+
+    std::fs::create_dir_all(path.parent().unwrap())?;
+    std::fs::write(path, content)?;
     Ok(())
 }
 
@@ -176,7 +356,30 @@ pub fn get_app_details(id: &str) -> Option<AppDetails> {
             .get("windowmaximize")
             .and_then(|x| x.parse::<bool>().ok())
             .unwrap_or(false),
-        user_agent: settings.get("useragent").map(|x| x.to_string()),
+        user_agent: settings
+            .get("useragent")
+            .map(|x| x.to_string())
+            .filter(|x| !x.is_empty()),
+        allowed_domains: settings.get("domains").and_then(|x| {
+            let domains: Vec<String> = x
+                .split(',')
+                .map(|d| d.trim().to_lowercase())
+                .filter(|d| !d.is_empty())
+                .collect();
+            (!domains.is_empty()).then_some(domains)
+        }),
+        proxy_url: settings
+            .get("proxyurl")
+            .map(|x| x.to_string())
+            .filter(|x| !x.is_empty()),
+        autostart: settings
+            .get("autostart")
+            .and_then(|x| x.parse::<bool>().ok())
+            .unwrap_or(false),
+        run_in_background: settings
+            .get("background")
+            .and_then(|x| x.parse::<bool>().ok())
+            .unwrap_or(false),
     })
 }
 
@@ -193,6 +396,10 @@ pub async fn uninstall_app(id: &str) -> anyhow::Result<()> {
     }
     if app_cache_dir.exists() {
         std::fs::remove_dir_all(app_cache_dir)?;
+    }
+    let autostart_path = autostart_desktop_path(id);
+    if autostart_path.exists() {
+        std::fs::remove_file(autostart_path)?;
     }
     delete_app_details(id)?;
 
@@ -290,4 +497,54 @@ pub fn copy_app_dir(old_id: &str, new_id: &str) -> anyhow::Result<()> {
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn permission_storage_roundtrip() {
+        let details = AppDetails::new(
+            "testperm01".to_string(),
+            "Test".to_string(),
+            "https://example.com".to_string(),
+        );
+        details.save().unwrap();
+
+        set_app_permission("testperm01", "https://example.com", "camera", true).unwrap();
+        set_app_permission("testperm01", "https://example.com", "microphone", true).unwrap();
+        set_app_permission("testperm01", "https://other.example.com:8443", "geolocation", false)
+            .unwrap();
+
+        assert_eq!(
+            get_app_permission("testperm01", "https://example.com", "camera"),
+            Some(true)
+        );
+
+        let summaries = get_permission_summaries("testperm01");
+        let (_, kinds) = summaries
+            .iter()
+            .find(|(o, _)| o == "https://example.com")
+            .expect("allowed origin missing from summaries");
+        assert!(kinds.contains(&"camera".to_string()));
+        assert!(kinds.contains(&"microphone".to_string()));
+        // Origins whose stored decisions are all "deny" are not listed.
+        assert!(!summaries.iter().any(|(o, _)| o == "https://other.example.com:8443"));
+
+        clear_origin_permissions("testperm01", "https://example.com").unwrap();
+        assert_eq!(
+            get_app_permission("testperm01", "https://example.com", "camera"),
+            None
+        );
+        // A save must not wipe unrelated permission keys.
+        set_app_permission("testperm01", "https://example.com", "notifications", true).unwrap();
+        details.save().unwrap();
+        assert_eq!(
+            get_app_permission("testperm01", "https://example.com", "notifications"),
+            Some(true)
+        );
+
+        delete_app_details("testperm01").unwrap();
+    }
 }

--- a/src/create_app_dialog.rs
+++ b/src/create_app_dialog.rs
@@ -100,7 +100,14 @@ mod imp {
                 self.url_entry.set_text(url.as_str());
                 self.url_entry.set_show_apply_button(true);
 
-                match util::get_website_meta(url).await {
+                // Prefer rendering the page in a hidden webview (sees
+                // JS-driven titles/icons, bypasses bot-blocking); fall
+                // back to a plain HTTP scrape.
+                let meta = match util::get_website_meta_via_webview(url.clone()).await {
+                    Ok(meta) => Ok(meta),
+                    Err(_) => util::get_website_meta(url).await,
+                };
+                match meta {
                     Ok(meta) => {
                         self.title_entry
                             .set_text(meta.title.unwrap_or_default().as_str());

--- a/src/gtk/help-overlay.blp
+++ b/src/gtk/help-overlay.blp
@@ -20,5 +20,54 @@ ShortcutsWindow help_overlay {
         action-name: 'app.quit';
       }
     }
+
+    ShortcutsGroup {
+      title: C_('shortcut window', 'Web App');
+
+      ShortcutsShortcut {
+        title: C_('shortcut window', 'Go Back');
+        action-name: 'win.back';
+      }
+
+      ShortcutsShortcut {
+        title: C_('shortcut window', 'Go Forward');
+        action-name: 'win.forward';
+      }
+
+      ShortcutsShortcut {
+        title: C_('shortcut window', 'Reload');
+        accelerator: '<primary>r';
+      }
+
+      ShortcutsShortcut {
+        title: C_('shortcut window', 'Reload Without Cache');
+        accelerator: '<primary><shift>r';
+      }
+
+      ShortcutsShortcut {
+        title: C_('shortcut window', 'Stop Loading');
+        accelerator: 'Escape';
+      }
+
+      ShortcutsShortcut {
+        title: C_('shortcut window', 'Zoom In');
+        accelerator: '<primary>plus';
+      }
+
+      ShortcutsShortcut {
+        title: C_('shortcut window', 'Zoom Out');
+        accelerator: '<primary>minus';
+      }
+
+      ShortcutsShortcut {
+        title: C_('shortcut window', 'Reset Zoom');
+        accelerator: '<primary>0';
+      }
+
+      ShortcutsShortcut {
+        title: C_('shortcut window', 'Go to Start Page');
+        accelerator: '<alt>Home';
+      }
+    }
   }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,9 +52,12 @@ fn main() -> glib::ExitCode {
     // Create a new GtkApplication. The application manages our main loop,
     // application windows, integration with the window manager/compositor, and
     // desktop features such as file opening and single-instance applications.
-    let app = SpiderApplication::new(
-        &(gio::ApplicationFlags::HANDLES_COMMAND_LINE | gio::ApplicationFlags::NON_UNIQUE),
-    );
+    //
+    // Every app id (io.github.zaedus.spider[.<app-id>]) is its own unique
+    // instance so launching an app that is already running in the
+    // background re-presents its existing window instead of spawning a
+    // duplicate process.
+    let app = SpiderApplication::new(&gio::ApplicationFlags::HANDLES_COMMAND_LINE);
 
     // Run the application. This function will block until the application
     // exits. Upon return, we have our exit code to return to the shell. (This

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,12 +1,14 @@
 use anyhow::bail;
 use anyhow::{anyhow, Result};
 use futures::future::join_all;
-use gtk::{gdk, gio, prelude::*};
+use gtk::{gdk, gio, glib, prelude::*};
 use isahc::{config, prelude::*};
 use lazy_static::lazy_static;
 use scraper::{Html, Selector};
 use std::collections::HashSet;
 use url::Url;
+
+use webkit::prelude::WebViewExt;
 
 #[derive(Debug)]
 pub struct WebsiteMeta {
@@ -206,7 +208,7 @@ async fn get_image_metadata(url: Url) -> Result<Image> {
     let is_svg = content_type.as_deref() == Some("image/svg+xml")
         || url
             .path_segments()
-            .and_then(|x| x.last())
+            .and_then(|mut x| x.next_back())
             .is_some_and(|name| name.to_ascii_lowercase().ends_with(".svg"));
     if let Some(ct) = content_type.as_deref() {
         if !is_svg && !ct.starts_with("image/") {
@@ -263,6 +265,130 @@ pub async fn get_website_meta(url: Url) -> Result<WebsiteMeta> {
         icon: best_image.cloned(),
         title,
     })
+}
+
+/// How long to wait for a page to load in the hidden metadata webview
+const WEBVIEW_META_TIMEOUT_SECS: u32 = 20;
+
+/// Extracts website data (title + favicon candidates) by rendering the page
+/// in an offscreen ephemeral WebKitWebView and running JavaScript on it.
+///
+/// Unlike [`get_website_meta`], this sees the page exactly like the browser
+/// will: JS-rendered titles/icons are picked up and responses that block
+/// non-browser clients still succeed.
+pub async fn get_website_meta_via_webview(url: Url) -> Result<WebsiteMeta> {
+    let uri = url.to_string();
+
+    let context = webkit::WebContext::new();
+    let session = webkit::NetworkSession::new_ephemeral();
+    let settings = webkit::Settings::builder()
+        .enable_javascript_markup(true)
+        .media_playback_requires_user_gesture(true)
+        .enable_html5_database(false)
+        .enable_html5_local_storage(false)
+        .build();
+    let webview = webkit::WebView::builder()
+        .web_context(&context)
+        .network_session(&session)
+        .settings(&settings)
+        .user_content_manager(&webkit::UserContentManager::new())
+        .build();
+
+    let (sender, receiver) = async_channel::bounded::<Result<WebsiteMeta>>(1);
+
+    // Collects everything in one pass. Icon hrefs are absolute since
+    // `link.href` resolves them against the document. Tab/newline are
+    // stripped so the result can be parsed line-by-line.
+    const EXTRACT_SCRIPT: &str = r#"
+(() => {
+  const lines = [];
+  lines.push(`T\t${(document.title || "").replace(/[\t\r\n]/g, " ")}`);
+  for (const link of document.querySelectorAll(
+    "link[rel~='icon'], link[rel='shortcut icon'], link[rel='apple-touch-icon']"
+  )) {
+    if (!link.href) continue;
+    let size = 0;
+    const sizes = (link.sizes && link.sizes.value) || "";
+    for (const match of sizes.matchAll(/(\d+)x\d+/g)) {
+      size = Math.max(size, parseInt(match[1]));
+    }
+    if (!Number.isFinite(size)) size = 0;
+    lines.push(`I\t${size}\t${link.href}`);
+  }
+  return lines.join("\n");
+})()
+"#;
+
+    webview.connect_load_changed(move |webview, event| {
+        if event != webkit::LoadEvent::Finished {
+            return;
+        }
+        let webview = webview.clone();
+        let sender = sender.clone();
+        let url = url.clone();
+        glib::spawn_future_local(async move {
+            let result = match webview
+                .evaluate_javascript_future(EXTRACT_SCRIPT, None, None)
+                .await
+            {
+                Ok(value) => {
+                    let text = value
+                        .to_string_as_bytes()
+                        .map(|bytes| String::from_utf8_lossy(&bytes).to_string())
+                        .unwrap_or_default();
+                    parse_meta_text(&text, &url).await
+                }
+                Err(err) => Err(anyhow!("{err}")),
+            };
+            let _ = sender.send(result).await;
+        });
+    });
+
+    webview.load_uri(uri.as_str());
+
+    match futures::future::select(
+        Box::pin(receiver.recv()),
+        Box::pin(glib::timeout_future_seconds(WEBVIEW_META_TIMEOUT_SECS)),
+    )
+    .await
+    {
+        futures::future::Either::Left((result, _)) => result.map_err(|e| anyhow!("{e}"))?,
+        futures::future::Either::Right(_) => bail!("Timed out loading {uri}"),
+    }
+}
+
+/// Parses the tab-separated output of [`EXTRACT_SCRIPT`]:
+/// `T\t<title>` then `I\t<size>\t<href>` lines.
+async fn parse_meta_text(text: &str, url: &Url) -> Result<WebsiteMeta> {
+    let mut title = None;
+    let mut icons: Vec<(u32, Url)> = Vec::new();
+
+    for line in text.lines() {
+        match line.split_once('\t') {
+            Some(("T", value)) => {
+                if !value.is_empty() {
+                    title = Some(value.to_string());
+                }
+            }
+            Some(("I", rest)) => {
+                if let Some((size, href)) = rest.split_once('\t') {
+                    if let (Ok(size), Ok(href)) = (size.parse::<u32>(), url.join(href)) {
+                        icons.push((size, href));
+                    }
+                }
+            }
+            _ => (),
+        }
+    }
+
+    // Prefer the biggest declared icon; fall back to whatever exists
+    let best = icons.iter().max_by_key(|(size, _)| *size);
+    let icon = match best {
+        Some((_, href)) => Some(get_image_metadata(href.clone()).await?),
+        None => None,
+    };
+
+    Ok(WebsiteMeta { icon, title })
 }
 
 pub async fn icon_from_dialog(


### PR DESCRIPTION
- Website permissions: camera/microphone/geolocation/notification prompts are remembered per origin and manageable/revocable from the app's settings page (live-updating list)
- App metadata (title + high quality icon) fetched by rendering the site in an offscreen webview, falling back to HTTP scraping
- Autostart on login via XDG autostart entries; run in background keeps apps alive when the window is closed and relaunch re-presents them
- Optional domain restriction: off-site navigations open externally
- Extra keybinds: reload, force reload, stop, zoom in/out/reset, start page
- Per-app HTTP proxy settings
- window.open pop ups open in a small window sharing the app session
- Single instance per app id; media capture (getUserMedia) enabled